### PR TITLE
Resolve weather promise when API key is absent

### DIFF
--- a/lib/Weather.js
+++ b/lib/Weather.js
@@ -16,7 +16,7 @@ class Weather {
   get () {
     return new Promise(async (resolve, reject) => {
       if (!OPEN_WEATHER_API_KEY) {
-        return
+        resolve(null)
       }
 
       OpenWeather.setLang(OPEN_WEATHER_LANG)


### PR DESCRIPTION
Hi! I stumbled upon your project while looking for a way to read Feedbin on my Kindle -- thanks for building it. The `/generate` endpoint was hanging when I tried it out because a promise was never resolving.